### PR TITLE
Add dev server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ npm run build
 ```
 which simply runs `tsc` to compile files to the `dist/` folder.
 
+Start a development server:
+```bash
+bun run dev:web
+```
+This builds the project and serves `index.html` on a local web server for easy testing.
+
 Open `index.html` in a browser to test the game. The basic implementation draws an isometric board and allows swipe gestures to rotate or move the current piece.
 
 ## Folder Structure

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Isometric Tetris prototype built with PixiJS and TypeScript",
   "main": "dist/main.js",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "dev:web": "bun run build && bun x serve ."
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `dev:web` script for running a local dev server
- document the new script in README

## Testing
- `npm install`
- `bun run dev:web`

------
https://chatgpt.com/codex/tasks/task_e_68504813dac88320a74b25ea88485ba1